### PR TITLE
Wagtail 5.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        python: ["3.8", "3.9", "3.10", "3.11"]
+        python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add support for Wagtail 5.2
 - Add Wagtail 5.2 and Python 3.12 in test matrices @katdom13
 
 ## 0.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Wagtail Footnotes Changelog
 
+## Unreleased
+
+- Add Wagtail 5.2 and Python 3.12 in test matrices @katdom13
+
 ## 0.10.0
 
 - Add tests. (https://github.com/torchbox/wagtail-footnotes/pull/49) @nickmoreton

--- a/README.md
+++ b/README.md
@@ -110,11 +110,11 @@ tox
 To run tests for a specific environment:
 
 ```shell
-tox -e python3.11-django4.2-wagtail5.0
+tox -e python3.11-django4.2-wagtail5.2
 ```
 
 To run a single test method in a specific environment:
 
 ```shell
-tox -e python3.11-django4.2-wagtail5.0 -- tests.test.test_blocks.TestBlocks.test_block_with_features
+tox -e python3.11-django4.2-wagtail5.2 -- tests.test.test_blocks.TestBlocks.test_block_with_features
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Framework :: Django",
     "Framework :: Django :: 3",
     "Framework :: Django :: 3.2",

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,9 @@
 min_version = 4.0
 
 envlist =
-    python{3.8,3.9,3.10}-django{3.2}-wagtail{4.1,5.0,5.1,5.2}
-    python{3.9,3.10,3.11}-django{4.1}-wagtail{4.1,5.0,5.1,5.2}
-    python{3.10,3.11}-django{4.2}-wagtail{5.0,5.1,5.2}
+    python{3.8,3.9,3.10}-django{3.2}-wagtail{4.1,5.1,5.2}
+    python{3.9,3.10,3.11}-django{4.1}-wagtail{4.1,5.1,5.2}
+    python{3.10,3.11}-django{4.2}-wagtail{5.1,5.2}
     python3.12-django4.2-wagtail5.2
 
 [gh-actions]
@@ -32,7 +32,6 @@ deps =
     django4.2: Django>=4.2,<4.3
 
     wagtail4.1: wagtail>=4.1,<4.2
-    wagtail5.0: wagtail>=5.0,<5.1
     wagtail5.1: wagtail>=5.1,<5.2
     wagtail5.2: wagtail>=5.2,<5.3
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,10 @@
 min_version = 4.0
 
 envlist =
-    python{3.8,3.9,3.10}-django{3.2}-wagtail{4.1,5.0,5.1}
-    python{3.9,3.10,3.11}-django{4.1}-wagtail{4.1,5.0,5.1}
-    python{3.10,3.11}-django{4.2}-wagtail{5.0,5.1}
+    python{3.8,3.9,3.10}-django{3.2}-wagtail{4.1,5.0,5.1,5.2}
+    python{3.9,3.10,3.11}-django{4.1}-wagtail{4.1,5.0,5.1,5.2}
+    python{3.10,3.11}-django{4.2}-wagtail{5.0,5.1,5.2}
+    python3.12-django4.2-wagtail5.2
 
 [gh-actions]
 python =
@@ -12,6 +13,7 @@ python =
     3.9: python3.9
     3.10: python3.10
     3.11: python3.11
+    3.12: python3.12
 
 
 [testenv]
@@ -31,7 +33,8 @@ deps =
 
     wagtail4.1: wagtail>=4.1,<4.2
     wagtail5.0: wagtail>=5.0,<5.1
-    wagtail5.1: wagtail>=5.1rc1,<5.2
+    wagtail5.1: wagtail>=5.1,<5.2
+    wagtail5.2: wagtail>=5.2,<5.3
 
 
 install_command = python -Im pip install -U {opts} {packages}

--- a/wagtail_footnotes/blocks.py
+++ b/wagtail_footnotes/blocks.py
@@ -53,7 +53,7 @@ class RichTextBlockWithFootnotes(RichTextBlock):
         return mark_safe(FIND_FOOTNOTE_TAG.sub(replace_tag, html))  # noqa: S308
 
     def render(self, value, context=None):
-        if not self.get_template(context=context):
+        if not self.get_template(value=value, context=context):
             return self.render_basic(value, context=context)
 
         html = super().render(value, context=context)

--- a/wagtail_footnotes/blocks.py
+++ b/wagtail_footnotes/blocks.py
@@ -2,6 +2,7 @@ import re
 
 from django.core.exceptions import ValidationError
 from django.utils.safestring import mark_safe
+from wagtail import VERSION as WAGTAIL_VERSION
 from wagtail.blocks import RichTextBlock
 from wagtail.models import Page
 
@@ -53,7 +54,9 @@ class RichTextBlockWithFootnotes(RichTextBlock):
         return mark_safe(FIND_FOOTNOTE_TAG.sub(replace_tag, html))  # noqa: S308
 
     def render(self, value, context=None):
-        if not self.get_template(value=value, context=context):
+        kwargs = {"value": value} if WAGTAIL_VERSION >= (5, 2) else {}
+
+        if not self.get_template(context=context, **kwargs):
             return self.render_basic(value, context=context)
 
         html = super().render(value, context=context)


### PR DESCRIPTION
## [Wagtail 5.2 release notes](https://docs.wagtail.org/en/stable/releases/5.2.html)

## Upstream PR: https://github.com/torchbox/wagtail-footnotes/pull/62

Changes:
- Add Wagtail 5.2 and Python 3.12 in test matrices, update CHANGELOG.md