### PR TITLE
Support/wagtail 64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Update tox testing to include Wagtail 6.3
+- Update tox testing to include Wagtail 6.3 and 6.4
 - Add tox testing for Django 5.1
 - Drop testing around python 3.8
 

--- a/README.md
+++ b/README.md
@@ -208,11 +208,11 @@ tox
 To run tests for a specific environment:
 
 ```shell
-tox -e python3.12-django5.0-wagtail6.0
+tox -e python3.12-django5.0-wagtail5.2
 ```
 
 To run a single test method in a specific environment:
 
 ```shell
-tox -e python3.12-django5.0-wagtail6.0 -- tests.test.test_blocks.TestBlocks.test_block_with_features
+tox -e python3.12-django5.0-wagtail5.2 -- tests.test.test_blocks.TestBlocks.test_block_with_features
 ```

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,9 @@
 min_version = 4.22
 
 envlist =
-    python{3.9,3.10,3.11}-django4.2-wagtail{5.2,6.2,6.3}
-    python{3.10,3.11,3.12}-django5.0-wagtail{5.2,6.2,6.3}
-    python{3.12,3.13}-django5.1-wagtail6.3
+    python{3.9,3.10,3.11}-django4.2-wagtail{5.2,6.3,6.4}
+    python{3.10,3.11,3.12}-django5.0-wagtail{5.2,6.3,6.4}
+    python{3.12,3.13}-django5.1-wagtail{6.3,6.4}
 
 [gh-actions]
 python =
@@ -12,6 +12,7 @@ python =
     3.10: python3.10
     3.11: python3.11
     3.12: python3.12
+    3.13: python3.13
 
 
 [testenv]
@@ -35,6 +36,7 @@ deps =
     wagtail5.2: wagtail>=5.2,<5.3
     wagtail6.2: wagtail>=6.2,<6.3
     wagtail6.3: wagtail>=6.3,<6.4
+    wagtail6.3: wagtail>=6.4,<6.5
 
 
 extras = testing

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ deps =
     wagtail5.2: wagtail>=5.2,<5.3
     wagtail6.2: wagtail>=6.2,<6.3
     wagtail6.3: wagtail>=6.3,<6.4
-    wagtail6.3: wagtail>=6.4,<6.5
+    wagtail6.4: wagtail>=6.4,<6.5
 
 
 extras = testing

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,6 @@ deps =
     django5.1: Django>=5.1,<5.2
 
     wagtail5.2: wagtail>=5.2,<5.3
-    wagtail6.2: wagtail>=6.2,<6.3
     wagtail6.3: wagtail>=6.3,<6.4
     wagtail6.4: wagtail>=6.4,<6.5
 


### PR DESCRIPTION
The changes primarily focus on updating the supported versions of Python, Django, and Wagtail, and removing support for older versions and adding some Wagtail version compatibility conditionals.

## Updates to testing environment and compatibility:

[tox.ini](https://github.com/torchbox-forks/wagtail-footnotes/blob/support/wagtail-64/tox.ini): Updated test matrix for Wagtail 6.4 [[1]](https://github.com/torchbox-forks/wagtail-footnotes/compare/main..support/wagtail-64#diff-ef2cef9f88b4fe09ca3082140e67f5ad34fb65fb6e228f119d3812261ae51449)

## Documentation updates:

[README](https://github.com/torchbox-forks/wagtail-footnotes/compare/main..support/wagtail-64#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5): Updated example tox command to use an argument that exists in the config.
[CHANGELOG.md](https://github.com/torchbox-forks/wagtail-footnotes/compare/main..support/wagtail-64#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed): Added an entry for the unreleased changes.